### PR TITLE
Kamera hinzufügen

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 dotnet_analyzer_diagnostic.category-Usage.severity = warning
 dotnet_diagnostic.IDE0072.severity = none
+dotnet_diagnostic.IDE0010.severity = none
 
 #### Core EditorConfig Options ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ dotnet_analyzer_diagnostic.category-Design.severity = warning
 dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 dotnet_analyzer_diagnostic.category-Usage.severity = warning
+dotnet_diagnostic.IDE0072.severity = none
 
 #### Core EditorConfig Options ####
 

--- a/scene/level/GameLevel.tscn
+++ b/scene/level/GameLevel.tscn
@@ -11,6 +11,7 @@ _tileManager = NodePath("LevelTileManager")
 _camera = NodePath("PlayerCamera")
 
 [node name="PlayerCamera" type="Camera2D" parent="."]
+limit_smoothed = true
 position_smoothing_enabled = true
 script = ExtResource("2_0aiww")
 

--- a/scene/level/GameLevel.tscn
+++ b/scene/level/GameLevel.tscn
@@ -11,6 +11,7 @@ _tileManager = NodePath("LevelTileManager")
 _camera = NodePath("PlayerCamera")
 
 [node name="PlayerCamera" type="Camera2D" parent="."]
+position_smoothing_enabled = true
 script = ExtResource("2_0aiww")
 
 [node name="LevelTileManager" type="Node2D" parent="." node_paths=PackedStringArray("_tileMap")]

--- a/scene/level/GameLevel.tscn
+++ b/scene/level/GameLevel.tscn
@@ -1,12 +1,17 @@
-[gd_scene load_steps=4 format=3 uid="uid://7h7m71uuto1n"]
+[gd_scene load_steps=5 format=3 uid="uid://7h7m71uuto1n"]
 
 [ext_resource type="Script" path="res://script/level/GameLevel.cs" id="1_v0801"]
+[ext_resource type="Script" path="res://script/level/PlayerCamera.cs" id="2_0aiww"]
 [ext_resource type="Script" path="res://script/level/tile/LevelTileManager.cs" id="2_l7ks5"]
 [ext_resource type="TileSet" uid="uid://m5d5tod6nelb" path="res://resource/tileset/TestTileSet.tres" id="3_g3n4h"]
 
-[node name="GameLevel" type="Node2D" node_paths=PackedStringArray("_tileManager")]
+[node name="GameLevel" type="Node2D" node_paths=PackedStringArray("_tileManager", "_camera")]
 script = ExtResource("1_v0801")
 _tileManager = NodePath("LevelTileManager")
+_camera = NodePath("PlayerCamera")
+
+[node name="PlayerCamera" type="Camera2D" parent="."]
+script = ExtResource("2_0aiww")
 
 [node name="LevelTileManager" type="Node2D" parent="." node_paths=PackedStringArray("_tileMap")]
 script = ExtResource("2_l7ks5")

--- a/script/level/GameLevel.cs
+++ b/script/level/GameLevel.cs
@@ -15,8 +15,8 @@ namespace INTOnlineCoop.Script.Level
 
         [ExportGroup("CameraSettings")]
         // Maximum pixel offsets of the camera to the terrain, used for calculating the horizontal camera limits
-        [Export] private int _cameraLimitOffsetX = 200;
-        [Export] private int _cameraLimitOffsetY = 80;
+        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetX = 200;
+        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetY = 80;
 
         private Image _terrainImage;
 

--- a/script/level/GameLevel.cs
+++ b/script/level/GameLevel.cs
@@ -10,6 +10,17 @@ namespace INTOnlineCoop.Script.Level
     public partial class GameLevel : Node2D
     {
         [Export] private LevelTileManager _tileManager;
+        [Export] private Camera2D _camera;
+
+        /// <summary>
+        /// Maximum pixel x-offset of the camera to the terrain, used for calculating the horizontal camera limits
+        /// </summary>
+        private const int CameraLimitOffsetX = 200;
+
+        /// <summary>
+        /// Maximum pixel y-offset of the camera to the terrain, used for calculating the vertical camera limits
+        /// </summary>
+        private const int CameraLimitOffsetY = 50;
 
         private Image _terrainImage;
 
@@ -20,6 +31,18 @@ namespace INTOnlineCoop.Script.Level
         public void Init(Image terrainImage)
         {
             _terrainImage = terrainImage;
+            if (_camera != null)
+            {
+                Vector2I tileSize = _tileManager?.GetTileSize() ?? Vector2I.Zero;
+                _camera.LimitLeft = -CameraLimitOffsetX;
+                _camera.LimitTop = -CameraLimitOffsetY * 2;
+                _camera.LimitRight = (terrainImage.GetWidth() * tileSize.X) + CameraLimitOffsetX;
+                _camera.LimitBottom = (terrainImage.GetHeight() * tileSize.Y) + CameraLimitOffsetY;
+
+                _camera.Position = new Vector2(terrainImage.GetWidth() * tileSize.X / 2f,
+                    terrainImage.GetHeight() * tileSize.Y / 2f);
+            }
+
             GD.Print("GameLevel initialized!");
         }
 

--- a/script/level/GameLevel.cs
+++ b/script/level/GameLevel.cs
@@ -9,14 +9,8 @@ namespace INTOnlineCoop.Script.Level
     /// </summary>
     public partial class GameLevel : Node2D
     {
-        [ExportGroup("Nodes")]
         [Export] private LevelTileManager _tileManager;
-        [Export] private Camera2D _camera;
-
-        [ExportGroup("CameraSettings")]
-        // Maximum pixel offsets of the camera to the terrain, used for calculating the horizontal camera limits
-        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetX = 200;
-        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetY = 80;
+        [Export] private PlayerCamera _camera;
 
         private Image _terrainImage;
 
@@ -30,13 +24,8 @@ namespace INTOnlineCoop.Script.Level
             if (_camera != null)
             {
                 Vector2I tileSize = _tileManager?.GetTileSize() ?? Vector2I.Zero;
-                _camera.LimitLeft = -_cameraLimitOffsetX;
-                _camera.LimitTop = -_cameraLimitOffsetY * 2;
-                _camera.LimitRight = (terrainImage.GetWidth() * tileSize.X) + _cameraLimitOffsetX;
-                _camera.LimitBottom = (terrainImage.GetHeight() * tileSize.Y) + _cameraLimitOffsetY;
-
-                _camera.Position = new Vector2(terrainImage.GetWidth() * tileSize.X / 2f,
-                    terrainImage.GetHeight() * tileSize.Y / 2f);
+                Vector2I terrainSize = new(terrainImage.GetWidth() * tileSize.X, terrainImage.GetHeight() * tileSize.Y);
+                _camera.Init(terrainSize);
             }
 
             GD.Print("GameLevel initialized!");

--- a/script/level/GameLevel.cs
+++ b/script/level/GameLevel.cs
@@ -9,18 +9,14 @@ namespace INTOnlineCoop.Script.Level
     /// </summary>
     public partial class GameLevel : Node2D
     {
+        [ExportGroup("Nodes")]
         [Export] private LevelTileManager _tileManager;
         [Export] private Camera2D _camera;
 
-        /// <summary>
-        /// Maximum pixel x-offset of the camera to the terrain, used for calculating the horizontal camera limits
-        /// </summary>
-        private const int CameraLimitOffsetX = 200;
-
-        /// <summary>
-        /// Maximum pixel y-offset of the camera to the terrain, used for calculating the vertical camera limits
-        /// </summary>
-        private const int CameraLimitOffsetY = 50;
+        [ExportGroup("CameraSettings")]
+        // Maximum pixel offsets of the camera to the terrain, used for calculating the horizontal camera limits
+        [Export] private int _cameraLimitOffsetX = 200;
+        [Export] private int _cameraLimitOffsetY = 80;
 
         private Image _terrainImage;
 
@@ -34,10 +30,10 @@ namespace INTOnlineCoop.Script.Level
             if (_camera != null)
             {
                 Vector2I tileSize = _tileManager?.GetTileSize() ?? Vector2I.Zero;
-                _camera.LimitLeft = -CameraLimitOffsetX;
-                _camera.LimitTop = -CameraLimitOffsetY * 2;
-                _camera.LimitRight = (terrainImage.GetWidth() * tileSize.X) + CameraLimitOffsetX;
-                _camera.LimitBottom = (terrainImage.GetHeight() * tileSize.Y) + CameraLimitOffsetY;
+                _camera.LimitLeft = -_cameraLimitOffsetX;
+                _camera.LimitTop = -_cameraLimitOffsetY * 2;
+                _camera.LimitRight = (terrainImage.GetWidth() * tileSize.X) + _cameraLimitOffsetX;
+                _camera.LimitBottom = (terrainImage.GetHeight() * tileSize.Y) + _cameraLimitOffsetY;
 
                 _camera.Position = new Vector2(terrainImage.GetWidth() * tileSize.X / 2f,
                     terrainImage.GetHeight() * tileSize.Y / 2f);

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Godot;
 
 namespace INTOnlineCoop.Script.Level
@@ -8,6 +10,10 @@ namespace INTOnlineCoop.Script.Level
     public partial class PlayerCamera : Camera2D
     {
         [Export(PropertyHint.Range, "0,500,")] private int _cameraSpeed = 10;
+        [ExportGroup("Zoom")]
+        [Export(PropertyHint.Range, "0,1,")] private float _zoomSize = 0.1f;
+        [Export(PropertyHint.Range, "0.01,2,")] private float _minZoom = 0.1f;
+        [Export(PropertyHint.Range, "0.01,2,")] private float _maxZoom = 2f;
 
         /// <summary>
         /// Called every frame
@@ -36,6 +42,29 @@ namespace INTOnlineCoop.Script.Level
             }
 
             Position += moveVector * _cameraSpeed;
+        }
+
+        /// <summary>
+        /// Called when an InputEvent occurs
+        /// </summary>
+        /// <param name="event">The input event</param>
+        public override void _UnhandledInput(InputEvent @event)
+        {
+            if (@event is InputEventMouseButton mouseEvent)
+            {
+                int zoomDirectionMultiplier = mouseEvent.ButtonIndex switch
+                {
+                    MouseButton.WheelUp => 1,
+                    MouseButton.WheelDown => -1,
+                    _ => 0
+                };
+
+                if (zoomDirectionMultiplier != 0)
+                {
+                    float newZoom = Math.Clamp(Zoom.X + (_zoomSize * zoomDirectionMultiplier), _minZoom, _maxZoom);
+                    Zoom = new Vector2(newZoom, newZoom);
+                }
+            }
         }
     }
 }

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -13,8 +13,8 @@ namespace INTOnlineCoop.Script.Level
 
         [ExportGroup("Limit")]
         // Maximum pixel offsets of the camera to the terrain, used for calculating the camera limits
-        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetX = 200;
-        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetY = 80;
+        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetX = 300;
+        [Export(PropertyHint.Range, "0,10000,")] private int _cameraLimitOffsetY = 120;
 
         [ExportGroup("Zoom")]
         [Export(PropertyHint.Range, "0,1,")] private float _zoomSize = 0.1f;
@@ -95,10 +95,6 @@ namespace INTOnlineCoop.Script.Level
         {
             float halfViewportX = GetViewportRect().Size.X / 2 * (1 / Zoom.X);
             float halfViewportY = GetViewportRect().Size.Y / 2 * (1 / Zoom.Y);
-
-            GD.Print((GetViewportRect().Size.X / 2) + " " + (GetViewportRect().Size.Y / 2));
-            GD.Print(halfViewportX + " " + halfViewportY);
-
             float limitedX = Math.Clamp(Position.X, LimitLeft + halfViewportX, LimitRight - halfViewportX);
             float limitedY = Math.Clamp(Position.Y, LimitTop + halfViewportY, LimitBottom - halfViewportY);
             Position = new Vector2(limitedX, limitedY);

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -7,7 +7,7 @@ namespace INTOnlineCoop.Script.Level
     /// </summary>
     public partial class PlayerCamera : Camera2D
     {
-        [Export] private int _cameraSpeed = 10;
+        [Export(PropertyHint.Range, "0,500,")] private int _cameraSpeed = 10;
 
         /// <summary>
         /// Called every frame

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -42,6 +42,26 @@ namespace INTOnlineCoop.Script.Level
         }
 
         /// <summary>
+        /// Moves the camera to a position
+        /// </summary>
+        /// <param name="newPosition">New position of the camera</param>
+        public void MoveCamera(Vector2 newPosition)
+        {
+            Position = newPosition;
+            LimitPosition();
+        }
+
+        /// <summary>
+        /// Changes the zoom level of the camera
+        /// </summary>
+        /// <param name="newZoomLevel">New zoom level</param>
+        public void ChangeCameraZoom(float newZoomLevel)
+        {
+            float clampedZoom = Math.Clamp(newZoomLevel, _minZoom, _maxZoom);
+            Zoom = new Vector2(clampedZoom, clampedZoom);
+        }
+
+        /// <summary>
         /// Called every frame
         /// </summary>
         public override async void _Process(double delta)

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -1,0 +1,41 @@
+using Godot;
+
+namespace INTOnlineCoop.Script.Level
+{
+    /// <summary>
+    /// Camera of the player
+    /// </summary>
+    public partial class PlayerCamera : Camera2D
+    {
+        private const int CameraSpeed = 10;
+
+        /// <summary>
+        /// Called every frame
+        /// </summary>
+        public override void _Process(double delta)
+        {
+            Vector2I moveVector = Vector2I.Zero;
+            if (Input.IsActionPressed("camera_left"))
+            {
+                moveVector.X -= 1;
+            }
+
+            if (Input.IsActionPressed("camera_up"))
+            {
+                moveVector.Y -= 1;
+            }
+
+            if (Input.IsActionPressed("camera_right"))
+            {
+                moveVector.X += 1;
+            }
+
+            if (Input.IsActionPressed("camera_down"))
+            {
+                moveVector.Y += 1;
+            }
+
+            Position += moveVector * CameraSpeed;
+        }
+    }
+}

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -7,7 +7,7 @@ namespace INTOnlineCoop.Script.Level
     /// </summary>
     public partial class PlayerCamera : Camera2D
     {
-        private const int CameraSpeed = 10;
+        [Export] private int _cameraSpeed = 10;
 
         /// <summary>
         /// Called every frame
@@ -35,7 +35,7 @@ namespace INTOnlineCoop.Script.Level
                 moveVector.Y += 1;
             }
 
-            Position += moveVector * CameraSpeed;
+            Position += moveVector * _cameraSpeed;
         }
     }
 }

--- a/script/level/PlayerCamera.cs
+++ b/script/level/PlayerCamera.cs
@@ -10,6 +10,7 @@ namespace INTOnlineCoop.Script.Level
     public partial class PlayerCamera : Camera2D
     {
         [Export(PropertyHint.Range, "0,500,")] private int _cameraSpeed = 10;
+        [Export(PropertyHint.Range, "0,200,")] private int _mouseMoveDistance = 50;
 
         [ExportGroup("Limit")]
         // Maximum pixel offsets of the camera to the terrain, used for calculating the camera limits
@@ -40,23 +41,24 @@ namespace INTOnlineCoop.Script.Level
         /// </summary>
         public override void _Process(double delta)
         {
+            Vector2 mousePosition = GetViewport().GetMousePosition();
             Vector2I moveVector = Vector2I.Zero;
-            if (Input.IsActionPressed("camera_left"))
+            if (Input.IsActionPressed("camera_left") || mousePosition.X <= _mouseMoveDistance)
             {
                 moveVector.X -= 1;
             }
 
-            if (Input.IsActionPressed("camera_up"))
+            if (Input.IsActionPressed("camera_up") || mousePosition.Y <= _mouseMoveDistance)
             {
                 moveVector.Y -= 1;
             }
 
-            if (Input.IsActionPressed("camera_right"))
+            if (Input.IsActionPressed("camera_right") || mousePosition.X >= GetViewportRect().Size.X - _mouseMoveDistance)
             {
                 moveVector.X += 1;
             }
 
-            if (Input.IsActionPressed("camera_down"))
+            if (Input.IsActionPressed("camera_down") || mousePosition.Y >= GetViewportRect().Size.Y - _mouseMoveDistance)
             {
                 moveVector.Y += 1;
             }
@@ -74,9 +76,9 @@ namespace INTOnlineCoop.Script.Level
         /// <param name="event">The input event</param>
         public override void _UnhandledInput(InputEvent @event)
         {
-            if (@event is InputEventMouseButton mouseEvent)
+            if (@event is InputEventMouseButton mouseButtonEvent)
             {
-                int zoomDirectionMultiplier = mouseEvent.ButtonIndex switch
+                int zoomDirectionMultiplier = mouseButtonEvent.ButtonIndex switch
                 {
                     MouseButton.WheelUp => 1,
                     MouseButton.WheelDown => -1,

--- a/script/level/tile/LevelTileManager.cs
+++ b/script/level/tile/LevelTileManager.cs
@@ -19,6 +19,10 @@ namespace INTOnlineCoop.Script.Level.Tile
         /// <param name="useTerrains">If terrains should be used instead of tiles</param>
         public void InitTileMap(Image terrainImage, bool useTerrains = false)
         {
+            if (terrainImage == null)
+            {
+                return;
+            }
             System.Collections.Generic.Dictionary<Color, Array<Vector2I>> pixelCache = new();
             for (int x = 0; x < terrainImage.GetWidth(); x++)
             {
@@ -74,6 +78,15 @@ namespace INTOnlineCoop.Script.Level.Tile
                     _tileMap.SetCellsTerrainConnect(0, cachedCells, terrainInformation.Item1, terrainInformation.Item2);
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns the tile size of the TileMap
+        /// </summary>
+        /// <returns>Current tile size</returns>
+        public Vector2I GetTileSize()
+        {
+            return _tileMap == null ? Vector2I.Zero : _tileMap.TileSet.TileSize;
         }
     }
 }

--- a/script/ui/component/GeneratorSettingsContainer.cs
+++ b/script/ui/component/GeneratorSettingsContainer.cs
@@ -42,7 +42,7 @@ namespace INTOnlineCoop.Script.UI.Component
                 bool isNumericInput = int.TryParse(_seed, out int seed);
                 if (!isNumericInput)
                 {
-                    seed = _seed.GetHashCode();
+                    seed = unchecked((int)_seed.Hash());
                 }
 
                 return seed;


### PR DESCRIPTION
Fügt eine Kamera zum GameLevel hinzu. Kann (standardmäßig) mit den Pfeiltasten bewegt werden. Alternativ wird die Kamera bewegt wenn der Mauszeiger sich an den Bildschirmrand bewegt. Mithilfe des Mausrades kann man heraus-/heranzoomen.

Um die Kamera per Code zu steuern gibt es die public-Methoden `MoveCamera` und `ChangeCameraZoom`