### PR TITLE
Item-Struktur hinzufügen

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,10 @@ folder_colors={
 "res://script/": "pink"
 }
 
+[filesystem]
+
+import/blender/enabled=false
+
 [input]
 
 walk_left={

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -12,13 +12,13 @@ namespace INTOnlineCoop.Script.Item
         /// <summary>
         /// Handles the input for the activation item. Should be called every frame
         /// </summary>
-        /// <param name="playerPosition">Current position of the player</param>
+        /// <param name="characterPosition">Current position of the character</param>
         /// <param name="direction">Direction in which the character looks</param>
-        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
+        public void HandleInput(Vector2 characterPosition, CharacterFacingDirection direction)
         {
             if (!GameLevel.IsInputBlocked && Input.IsActionJustPressed("use_item"))
             {
-                UseItem(playerPosition);
+                UseItem(characterPosition);
             }
         }
 

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -13,17 +13,18 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the activation item
         /// </summary>
         /// <param name="inputEvent">Input event</param>
-        public void HandleInput(InputEvent inputEvent)
+        /// <param name="playerPosition">Current position of the player</param>
+        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
         {
             if (!GameLevel.IsInputBlocked && inputEvent.IsAction("use_item"))
             {
-                UseItem();
+                UseItem(playerPosition);
             }
         }
 
         /// <summary>
         /// Activates the item
         /// </summary>
-        protected abstract void UseItem();
+        protected abstract void UseItem(Vector2 targetPosition);
     }
 }

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -1,0 +1,29 @@
+using Godot;
+
+using INTOnlineCoop.Script.Level;
+
+namespace INTOnlineCoop.Script.Item
+{
+    /// <summary>
+    /// Item without any aiming
+    /// </summary>
+    public abstract class ActivationItem : IItem
+    {
+        /// <summary>
+        /// Handles the input for the activation item
+        /// </summary>
+        /// <param name="inputEvent">Input event</param>
+        public void HandleInput(InputEvent inputEvent)
+        {
+            if (!GameLevel.IsInputBlocked && inputEvent.IsAction("use_item"))
+            {
+                UseItem();
+            }
+        }
+
+        /// <summary>
+        /// Activates the item
+        /// </summary>
+        protected abstract void UseItem();
+    }
+}

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -7,13 +7,14 @@ namespace INTOnlineCoop.Script.Item
     /// <summary>
     /// Item without any aiming
     /// </summary>
-    public abstract class ActivationItem : IItem
+    public abstract partial class ActivationItem : Node, IItem
     {
         /// <summary>
         /// Handles the input for the activation item. Should be called every frame
         /// </summary>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(Vector2 playerPosition)
+        /// <param name="direction">Direction in which the character looks</param>
+        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
         {
             if (!GameLevel.IsInputBlocked && Input.IsActionJustPressed("use_item"))
             {

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -23,8 +23,9 @@ namespace INTOnlineCoop.Script.Item
         }
 
         /// <summary>
-        /// Activates the item
+        /// Activates the item at the given position
         /// </summary>
+        /// <param name="targetPosition">Target position for usage</param>
         protected abstract void UseItem(Vector2 targetPosition);
     }
 }

--- a/script/item/ActivationItem.cs
+++ b/script/item/ActivationItem.cs
@@ -10,13 +10,12 @@ namespace INTOnlineCoop.Script.Item
     public abstract class ActivationItem : IItem
     {
         /// <summary>
-        /// Handles the input for the activation item
+        /// Handles the input for the activation item. Should be called every frame
         /// </summary>
-        /// <param name="inputEvent">Input event</param>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        public void HandleInput(Vector2 playerPosition)
         {
-            if (!GameLevel.IsInputBlocked && inputEvent.IsAction("use_item"))
+            if (!GameLevel.IsInputBlocked && Input.IsActionJustPressed("use_item"))
             {
                 UseItem(playerPosition);
             }

--- a/script/item/AimingItem.cs
+++ b/script/item/AimingItem.cs
@@ -12,18 +12,17 @@ namespace INTOnlineCoop.Script.Item
         private int _rotation;
 
         /// <summary>
-        /// Handles the input for the aiming item
+        /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
-        /// <param name="inputEvent">Input event</param>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        public void HandleInput(Vector2 playerPosition)
         {
             if (GameLevel.IsInputBlocked)
             {
                 return;
             }
 
-            if (inputEvent.IsAction("use_item"))
+            if (Input.IsActionJustPressed("use_item"))
             {
                 UseItem(playerPosition, _rotation);
             }

--- a/script/item/AimingItem.cs
+++ b/script/item/AimingItem.cs
@@ -7,7 +7,7 @@ namespace INTOnlineCoop.Script.Item
     /// <summary>
     /// Item with aiming -> Only direction is required
     /// </summary>
-    public abstract class AimingItem : IItem
+    public abstract partial class AimingItem : Node, IItem
     {
         private int _rotation;
 
@@ -15,7 +15,8 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(Vector2 playerPosition)
+        /// <param name="direction">Direction in which the character looks</param>
+        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {

--- a/script/item/AimingItem.cs
+++ b/script/item/AimingItem.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Godot;
 
 using INTOnlineCoop.Script.Level;
@@ -10,6 +12,7 @@ namespace INTOnlineCoop.Script.Item
     public abstract partial class AimingItem : Node, IItem
     {
         private int _rotation;
+        private CharacterFacingDirection _lastFacingDirection;
 
         /// <summary>
         /// Handles the input for the aiming item. Should be called every frame
@@ -28,8 +31,25 @@ namespace INTOnlineCoop.Script.Item
                 UseItem(playerPosition, _rotation);
             }
 
-            //TODO: Add rotation change
-            _rotation = _rotation;
+            if (direction != _lastFacingDirection)
+            {
+                _rotation += direction == CharacterFacingDirection.Left ? 180 : -180;
+                _lastFacingDirection = direction;
+            }
+
+            int rotationModifier = 0;
+            if (Input.IsActionPressed("aim_up"))
+            {
+                rotationModifier += direction == CharacterFacingDirection.Left ? 1 : -1;
+            }
+            if (Input.IsActionPressed("aim_down"))
+            {
+                rotationModifier += direction == CharacterFacingDirection.Left ? -1 : 1;
+            }
+
+            _rotation = direction == CharacterFacingDirection.Left
+                ? Math.Clamp(_rotation + rotationModifier, 180, 360)
+                : Math.Clamp(_rotation + rotationModifier, 0, 180);
         }
 
         /// <summary>

--- a/script/item/AimingItem.cs
+++ b/script/item/AimingItem.cs
@@ -17,9 +17,9 @@ namespace INTOnlineCoop.Script.Item
         /// <summary>
         /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
-        /// <param name="playerPosition">Current position of the player</param>
+        /// <param name="characterPosition">Current position of the character</param>
         /// <param name="direction">Direction in which the character looks</param>
-        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
+        public void HandleInput(Vector2 characterPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {
@@ -28,7 +28,7 @@ namespace INTOnlineCoop.Script.Item
 
             if (Input.IsActionJustPressed("use_item"))
             {
-                UseItem(playerPosition, _rotation);
+                UseItem(characterPosition, _rotation);
             }
 
             if (direction != _lastFacingDirection)

--- a/script/item/AimingItem.cs
+++ b/script/item/AimingItem.cs
@@ -1,0 +1,42 @@
+using Godot;
+
+using INTOnlineCoop.Script.Level;
+
+namespace INTOnlineCoop.Script.Item
+{
+    /// <summary>
+    /// Item with aiming -> Only direction is required
+    /// </summary>
+    public abstract class AimingItem : IItem
+    {
+        private int _rotation;
+
+        /// <summary>
+        /// Handles the input for the aiming item
+        /// </summary>
+        /// <param name="inputEvent">Input event</param>
+        /// <param name="playerPosition">Current position of the player</param>
+        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        {
+            if (GameLevel.IsInputBlocked)
+            {
+                return;
+            }
+
+            if (inputEvent.IsAction("use_item"))
+            {
+                UseItem(playerPosition, _rotation);
+            }
+
+            //TODO: Add rotation change
+            _rotation = _rotation;
+        }
+
+        /// <summary>
+        /// Activates the item at the given position with the given rotation
+        /// </summary>
+        /// <param name="targetPosition">Target position for usage</param>
+        /// <param name="rotation">Rotation of the aiming (up == 0, right == 90, etc.)</param>
+        protected abstract void UseItem(Vector2 targetPosition, int rotation);
+    }
+}

--- a/script/item/IItem.cs
+++ b/script/item/IItem.cs
@@ -11,6 +11,7 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the item
         /// </summary>
         /// <param name="inputEvent">Input event</param>
-        void HandleInput(InputEvent inputEvent);
+        /// <param name="playerPosition">Current position of the player</param>
+        void HandleInput(InputEvent inputEvent, Vector2 playerPosition);
     }
 }

--- a/script/item/IItem.cs
+++ b/script/item/IItem.cs
@@ -13,15 +13,15 @@ namespace INTOnlineCoop.Script.Item
         Right
     }
     /// <summary>
-    /// Interface for a player item
+    /// Interface for a character item
     /// </summary>
     public interface IItem
     {
         /// <summary>
         /// Handles the input for the item
         /// </summary>
-        /// <param name="playerPosition">Current position of the player</param>
+        /// <param name="characterPosition">Current position of the character</param>
         /// <param name="direction">Direction in which the character looks</param>
-        void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction);
+        void HandleInput(Vector2 characterPosition, CharacterFacingDirection direction);
     }
 }

--- a/script/item/IItem.cs
+++ b/script/item/IItem.cs
@@ -10,8 +10,7 @@ namespace INTOnlineCoop.Script.Item
         /// <summary>
         /// Handles the input for the item
         /// </summary>
-        /// <param name="inputEvent">Input event</param>
         /// <param name="playerPosition">Current position of the player</param>
-        void HandleInput(InputEvent inputEvent, Vector2 playerPosition);
+        void HandleInput(Vector2 playerPosition);
     }
 }

--- a/script/item/IItem.cs
+++ b/script/item/IItem.cs
@@ -3,6 +3,16 @@ using Godot;
 namespace INTOnlineCoop.Script.Item
 {
     /// <summary>
+    /// Direction in which the character looks
+    /// </summary>
+    public enum CharacterFacingDirection
+    {
+        /// <summary> Character looks to the left </summary>
+        Left,
+        /// <summary> Character looks to the right </summary>
+        Right
+    }
+    /// <summary>
     /// Interface for a player item
     /// </summary>
     public interface IItem
@@ -11,6 +21,7 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the item
         /// </summary>
         /// <param name="playerPosition">Current position of the player</param>
-        void HandleInput(Vector2 playerPosition);
+        /// <param name="direction">Direction in which the character looks</param>
+        void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction);
     }
 }

--- a/script/item/IItem.cs
+++ b/script/item/IItem.cs
@@ -1,0 +1,16 @@
+using Godot;
+
+namespace INTOnlineCoop.Script.Item
+{
+    /// <summary>
+    /// Interface for a player item
+    /// </summary>
+    public interface IItem
+    {
+        /// <summary>
+        /// Handles the input for the item
+        /// </summary>
+        /// <param name="inputEvent">Input event</param>
+        void HandleInput(InputEvent inputEvent);
+    }
+}

--- a/script/item/PositionItem.cs
+++ b/script/item/PositionItem.cs
@@ -9,7 +9,7 @@ namespace INTOnlineCoop.Script.Item
     /// <summary>
     /// Item for which the exact target position needs to be specified
     /// </summary>
-    public abstract class PositionItem : Node, IItem
+    public abstract partial class PositionItem : Node, IItem
     {
         private const int AimSpeed = 4;
         private Vector2 _initialPosition = Vector2.Zero;
@@ -18,7 +18,8 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the position item. Should be called every frame
         /// </summary>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(Vector2 playerPosition)
+        /// <param name="direction">Direction in which the character looks</param>
+        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {

--- a/script/item/PositionItem.cs
+++ b/script/item/PositionItem.cs
@@ -1,0 +1,45 @@
+using Godot;
+
+using INTOnlineCoop.Script.Level;
+
+namespace INTOnlineCoop.Script.Item
+{
+    /// <summary>
+    /// Item for which the exact target position needs to be specified
+    /// </summary>
+    public abstract class PositionItem : IItem
+    {
+        private Vector2 _initialPosition = Vector2.Zero;
+
+        /// <summary>
+        /// Handles the input for the position item
+        /// </summary>
+        /// <param name="inputEvent">Input event</param>
+        /// <param name="playerPosition">Current position of the player</param>
+        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        {
+            if (GameLevel.IsInputBlocked)
+            {
+                return;
+            }
+
+            if (_initialPosition == Vector2.Zero)
+            {
+                _initialPosition = playerPosition;
+            }
+
+            if (inputEvent.IsAction("use_item"))
+            {
+                UseItem(_initialPosition);
+            }
+
+            //TODO: Add position movement (input actions + mouse)
+        }
+
+        /// <summary>
+        /// Activates the item at the given position
+        /// </summary>
+        /// <param name="targetPosition">Target position for usage</param>
+        protected abstract void UseItem(Vector2 targetPosition);
+    }
+}

--- a/script/item/PositionItem.cs
+++ b/script/item/PositionItem.cs
@@ -17,9 +17,9 @@ namespace INTOnlineCoop.Script.Item
         /// <summary>
         /// Handles the input for the position item. Should be called every frame
         /// </summary>
-        /// <param name="playerPosition">Current position of the player</param>
+        /// <param name="characterPosition">Current position of the character</param>
         /// <param name="direction">Direction in which the character looks</param>
-        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
+        public void HandleInput(Vector2 characterPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {
@@ -28,7 +28,7 @@ namespace INTOnlineCoop.Script.Item
 
             if (_initialPosition == Vector2.Zero)
             {
-                _initialPosition = playerPosition;
+                _initialPosition = characterPosition;
             }
 
             if (Input.IsActionJustPressed("use_item"))

--- a/script/item/PositionItem.cs
+++ b/script/item/PositionItem.cs
@@ -7,16 +7,16 @@ namespace INTOnlineCoop.Script.Item
     /// <summary>
     /// Item for which the exact target position needs to be specified
     /// </summary>
-    public abstract class PositionItem : IItem
+    public abstract class PositionItem : Node, IItem
     {
+        private const int AimSpeed = 4;
         private Vector2 _initialPosition = Vector2.Zero;
 
         /// <summary>
-        /// Handles the input for the position item
+        /// Handles the input for the position item. Should be called every frame
         /// </summary>
-        /// <param name="inputEvent">Input event</param>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        public void HandleInput(Vector2 playerPosition)
         {
             if (GameLevel.IsInputBlocked)
             {
@@ -28,12 +28,44 @@ namespace INTOnlineCoop.Script.Item
                 _initialPosition = playerPosition;
             }
 
-            if (inputEvent.IsAction("use_item"))
+            if (Input.IsActionJustPressed("use_item"))
             {
                 UseItem(_initialPosition);
+                return;
             }
 
-            //TODO: Add position movement (input actions + mouse)
+            Vector2 movement = Vector2.Zero;
+            if (Input.IsActionPressed("walk_left"))
+            {
+                movement += Vector2.Left;
+            }
+
+            if (Input.IsActionPressed("walk_right"))
+            {
+                movement += Vector2.Right;
+            }
+
+            if (Input.IsActionPressed("aim_up"))
+            {
+                movement += Vector2.Up;
+            }
+
+            if (Input.IsActionPressed("aim_down"))
+            {
+                movement += Vector2.Down;
+            }
+
+            //TODO: Limit position to level area
+            _initialPosition += movement * AimSpeed;
+
+            if (Input.IsMouseButtonPressed(MouseButton.Left))
+            {
+                Camera2D activeCamera = GetViewport().GetCamera2D();
+                if (activeCamera != null)
+                {
+                    _initialPosition = activeCamera.GetGlobalMousePosition();
+                }
+            }
         }
 
         /// <summary>

--- a/script/item/PositionItem.cs
+++ b/script/item/PositionItem.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Godot;
 
 using INTOnlineCoop.Script.Level;
@@ -55,16 +57,19 @@ namespace INTOnlineCoop.Script.Item
                 movement += Vector2.Down;
             }
 
-            //TODO: Limit position to level area
             _initialPosition += movement * AimSpeed;
 
-            if (Input.IsMouseButtonPressed(MouseButton.Left))
+            Camera2D activeCamera = GetViewport().GetCamera2D();
+            if (activeCamera != null)
             {
-                Camera2D activeCamera = GetViewport().GetCamera2D();
-                if (activeCamera != null)
+                if (Input.IsMouseButtonPressed(MouseButton.Left))
                 {
                     _initialPosition = activeCamera.GetGlobalMousePosition();
                 }
+
+                float limitedX = Math.Clamp(_initialPosition.X, activeCamera.LimitLeft, activeCamera.LimitRight);
+                float limitedY = Math.Clamp(_initialPosition.Y, activeCamera.LimitTop, activeCamera.LimitBottom);
+                _initialPosition = new Vector2(limitedX, limitedY);
             }
         }
 

--- a/script/item/PowerAimingItem.cs
+++ b/script/item/PowerAimingItem.cs
@@ -7,7 +7,7 @@ namespace INTOnlineCoop.Script.Item
     /// <summary>
     /// Item with aiming -> Direction and power is required
     /// </summary>
-    public abstract class PowerAimingItem : IItem
+    public abstract partial class PowerAimingItem : Node, IItem
     {
         private int _rotation;
         private int _power;
@@ -16,7 +16,8 @@ namespace INTOnlineCoop.Script.Item
         /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(Vector2 playerPosition)
+        /// <param name="direction">Direction in which the character looks</param>
+        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {

--- a/script/item/PowerAimingItem.cs
+++ b/script/item/PowerAimingItem.cs
@@ -18,9 +18,9 @@ namespace INTOnlineCoop.Script.Item
         /// <summary>
         /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
-        /// <param name="playerPosition">Current position of the player</param>
+        /// <param name="characterPosition">Current position of the character</param>
         /// <param name="direction">Direction in which the character looks</param>
-        public void HandleInput(Vector2 playerPosition, CharacterFacingDirection direction)
+        public void HandleInput(Vector2 characterPosition, CharacterFacingDirection direction)
         {
             if (GameLevel.IsInputBlocked)
             {
@@ -34,7 +34,7 @@ namespace INTOnlineCoop.Script.Item
 
             if (Input.IsActionJustReleased("use_item") && _power > 0)
             {
-                UseItem(playerPosition, _rotation, _power);
+                UseItem(characterPosition, _rotation, _power);
             }
 
             if (direction != _lastFacingDirection)

--- a/script/item/PowerAimingItem.cs
+++ b/script/item/PowerAimingItem.cs
@@ -1,0 +1,45 @@
+using Godot;
+
+using INTOnlineCoop.Script.Level;
+
+namespace INTOnlineCoop.Script.Item
+{
+    /// <summary>
+    /// Item with aiming -> Direction and power is required
+    /// </summary>
+    public abstract class PowerAimingItem : IItem
+    {
+        private int _rotation;
+        private int _power;
+
+        /// <summary>
+        /// Handles the input for the aiming item
+        /// </summary>
+        /// <param name="inputEvent">Input event</param>
+        /// <param name="playerPosition">Current position of the player</param>
+        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        {
+            if (GameLevel.IsInputBlocked)
+            {
+                return;
+            }
+
+            if (inputEvent.IsAction("use_item"))
+            {
+                UseItem(playerPosition, _rotation, _power);
+            }
+
+            //TODO: Add rotation + power change
+            _rotation = _rotation;
+            _power = _power;
+        }
+
+        /// <summary>
+        /// Activates the item at the given position with the given rotation and power
+        /// </summary>
+        /// <param name="targetPosition">Target position for usage</param>
+        /// <param name="rotation">Rotation of the aiming (up == 0, right == 90, etc.)</param>
+        /// <param name="power">Strength of the shot (maximum power = 100)</param>
+        protected abstract void UseItem(Vector2 targetPosition, int rotation, int power);
+    }
+}

--- a/script/item/PowerAimingItem.cs
+++ b/script/item/PowerAimingItem.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Godot;
 
 using INTOnlineCoop.Script.Level;
@@ -11,6 +13,7 @@ namespace INTOnlineCoop.Script.Item
     {
         private int _rotation;
         private int _power;
+        private CharacterFacingDirection _lastFacingDirection;
 
         /// <summary>
         /// Handles the input for the aiming item. Should be called every frame
@@ -24,14 +27,35 @@ namespace INTOnlineCoop.Script.Item
                 return;
             }
 
-            if (Input.IsActionJustPressed("use_item"))
+            if (Input.IsActionPressed("use_item"))
+            {
+                _power = Math.Min(_power++, 100);
+            }
+
+            if (Input.IsActionJustReleased("use_item") && _power > 0)
             {
                 UseItem(playerPosition, _rotation, _power);
             }
 
-            //TODO: Add rotation + power change
-            _rotation = _rotation;
-            _power = _power;
+            if (direction != _lastFacingDirection)
+            {
+                _rotation += direction == CharacterFacingDirection.Left ? 180 : -180;
+                _lastFacingDirection = direction;
+            }
+
+            int rotationModifier = 0;
+            if (Input.IsActionPressed("aim_up"))
+            {
+                rotationModifier += direction == CharacterFacingDirection.Left ? 1 : -1;
+            }
+            if (Input.IsActionPressed("aim_down"))
+            {
+                rotationModifier += direction == CharacterFacingDirection.Left ? -1 : 1;
+            }
+
+            _rotation = direction == CharacterFacingDirection.Left
+                ? Math.Clamp(_rotation + rotationModifier, 180, 360)
+                : Math.Clamp(_rotation + rotationModifier, 0, 180);
         }
 
         /// <summary>

--- a/script/item/PowerAimingItem.cs
+++ b/script/item/PowerAimingItem.cs
@@ -13,18 +13,17 @@ namespace INTOnlineCoop.Script.Item
         private int _power;
 
         /// <summary>
-        /// Handles the input for the aiming item
+        /// Handles the input for the aiming item. Should be called every frame
         /// </summary>
-        /// <param name="inputEvent">Input event</param>
         /// <param name="playerPosition">Current position of the player</param>
-        public void HandleInput(InputEvent inputEvent, Vector2 playerPosition)
+        public void HandleInput(Vector2 playerPosition)
         {
             if (GameLevel.IsInputBlocked)
             {
                 return;
             }
 
-            if (inputEvent.IsAction("use_item"))
+            if (Input.IsActionJustPressed("use_item"))
             {
                 UseItem(playerPosition, _rotation, _power);
             }

--- a/script/level/CharacterPositionGenerator.cs
+++ b/script/level/CharacterPositionGenerator.cs
@@ -10,7 +10,7 @@ namespace INTOnlineCoop.Script.Level
     /// <summary>
     /// 
     /// </summary>
-    public partial class PlayerPositionGenerator : RefCounted
+    public partial class CharacterPositionGenerator : RefCounted
     {
         private List<(int, int)> _surfacePoints;
         private int _haltonIndex;
@@ -44,7 +44,7 @@ namespace INTOnlineCoop.Script.Level
         }
 
         /// <summary>
-        /// Calculates the spawn position for the next player
+        /// Calculates the spawn position for the next character
         /// </summary>
         /// <param name="seed">Seed for randomness</param>
         /// <param name="characterHeight">Height of the character</param>
@@ -53,7 +53,7 @@ namespace INTOnlineCoop.Script.Level
         {
             if (_surfacePoints.Count == 0)
             {
-                GD.PrintErr("PlayerPositionGenerator not initialized!");
+                GD.PrintErr("CharacterPositionGenerator not initialized!");
                 return (0.0, 0.0);
             }
             double nextRandomPoint = Halton(_haltonIndex++, 2);


### PR DESCRIPTION
Fügt eine grundlegende Klassenstruktur für Items nach dem Klassendiagramm hinzu.


- Gegenstände, die kein Zielen benötigen -> `ActivationItem`
- Gegenstände, die überall im Level eingesetzt werden können -> `PositionItem`
- Gegenstände, die eine Richtung zur Nutzung benötigen -> `AimingItem`
- Gegenstände, die eine Richtung + Stärke zur Nutzung benötigen -> `PowerAimingItem` 

Ist noch ein Draft aufgrund der unvollständigen Implementierung der Eingabe